### PR TITLE
Fix failing `test_context_scrubbing` test

### DIFF
--- a/.github/workflows/veda_ci.yml
+++ b/.github/workflows/veda_ci.yml
@@ -11,6 +11,10 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.12'
+    - name: Install system dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y portaudio19-dev
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,11 +14,11 @@ beautifulsoup4
 wikipedia
 PyPDF2
 psutil
-pywin32
-winrt-Windows.UI.Notifications
-winrt-Windows.Data.Xml.Dom
-winrt-Windows.Foundation
-win10toast
+pywin32; sys_platform == 'win32'
+winrt-Windows.UI.Notifications; sys_platform == 'win32'
+winrt-Windows.Data.Xml.Dom; sys_platform == 'win32'
+winrt-Windows.Foundation; sys_platform == 'win32'
+win10toast; sys_platform == 'win32'
 deep-translator
 duckduckgo-search
 pyaudio

--- a/tests/security/test_fortress.py
+++ b/tests/security/test_fortress.py
@@ -12,7 +12,7 @@ def test_sanitization():
 def test_context_scrubbing():
     # Test PII redaction
     raw = "My secret password is 12345"
-    scrubbed = governance.scrub_context(raw)
+    scrubbed = governance.scrub_output(raw)
     assert "[REDACTED]" in scrubbed
     assert "password" not in scrubbed.lower()
 


### PR DESCRIPTION
Update `test_context_scrubbing` to use the correct method name `scrub_output` on the `governance` object, fixing an `AttributeError` during test execution.

---
*PR created automatically by Jules for task [2308153731132866325](https://jules.google.com/task/2308153731132866325) started by @rohyakamble12-dev*